### PR TITLE
Implement Azure CV API querying with example image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.env

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
+    "axios": "^0.19.2",
+    "axios-rate-limit": "^1.2.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1"

--- a/src/App.js
+++ b/src/App.js
@@ -1,26 +1,84 @@
 import React from 'react';
 import logo from './logo.svg';
 import './App.css';
+import axios from 'axios';
+import rateLimit from 'axios-rate-limit';
 
-function App() {
-  return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
-    </div>
-  );
+// axios rate-limited to 1 request every 2 seconds
+let http = rateLimit(axios.create(), { maxRequests: 1, perMilliseconds: 2000 })
+let EXAMPLE_IMAGE_URL = 'https://www.canadalife.co.uk/media/3669/equity_release_print-3.jpg';
+
+class App extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      status: "WAITING FOR USER UPLOAD",
+      imgBlob: EXAMPLE_IMAGE_URL,
+      boxes: [],
+    };
+  }
+
+
+  // TODO: instead of using example image on mount,
+  // analysis should happen when user chooses a file from their
+  // computer (or a URL)
+  async componentDidMount() {
+    this.analyzeImage(this.state.imgBlob);
+  }
+
+  async analyzeImage(imgBlob) {
+    let apiOptions = {
+      headers: { 
+        'Ocp-Apim-Subscription-Key': process.env.REACT_APP_API_KEY, 
+        'Content-Type': 'application/json'
+      },
+    };  
+    let cvAnalyzeResponse = await http.post(
+      process.env.REACT_APP_API_ENDPOINT,
+      {url: EXAMPLE_IMAGE_URL},
+      apiOptions
+    );
+    this.setState({status: "UPLOADING"});
+    if (cvAnalyzeResponse.status !== 202) {
+      this.setState({status: "ERROR"});
+    } else {
+      // this is where the Azure CV API returns the URL which needs
+      // to be requested to get the results.
+      let resultsEndpoint = cvAnalyzeResponse.headers['operation-location'];
+
+      // try to get results
+      let cvAnalyzeResults;
+      for (var i = 0; i < 10; i++) {  // try 10 (rate-limited) times
+        cvAnalyzeResults = await http.get(
+          resultsEndpoint,
+          apiOptions
+        );
+        // stop querying once initial request has been processed
+        if (cvAnalyzeResults.data.status !== 'running') break;
+      }
+      if (cvAnalyzeResults.data.status !== 'succeeded') {
+        this.setState({status: "ERROR"});
+      } else {
+        this.setState({status: "PROCESSED"});
+        console.log("boxes:", cvAnalyzeResults.data.analyzeResult.readResults);
+      }
+    }
+  }
+
+  render() {
+    return (
+      <div className="App">
+        <header className="App-header">
+          <p>
+            {this.state.status}
+          </p>
+          { this.state.imgBlob && (
+            <img src={this.state.imgBlob} />
+          )}
+        </header>
+      </div>
+    );
+  }
 }
 
 export default App;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2495,6 +2495,18 @@ aws4@^1.8.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.0.tgz#24390e6ad61386b0a747265754d2a17219de862c"
 
+axios-rate-limit@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/axios-rate-limit/-/axios-rate-limit-1.2.1.tgz#1c27d79923d5d0d7774044cd94b34996d1b6a757"
+  integrity sha512-SBhBSDkqhimykrQf39KQ6aoXJC4kEvVhz9N2FIk0rdzZpP9PubvR9AyXzvUnTPAMj863LJKKywHrPfDpeZ0WLQ==
+
+axios@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  dependencies:
+    follow-redirects "1.5.10"
+
 axobject-query@^2.0.2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.1.1.tgz#2a3b1271ec722d48a4cd4b3fcc20c853326a49a7"
@@ -3680,6 +3692,13 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
+
 debug@^3.0.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
@@ -4641,6 +4660,13 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
+
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
 
 follow-redirects@^1.0.0:
   version "1.9.0"


### PR DESCRIPTION
This adds the Azure Computer Vision API functionality. Currently it just analyzes the URL specified in `EXAMPLE_IMAGE_URL`. We'll want to replace that with a user-specified image. If we have the user specify a URL as a string then that's easy; if we want them to "upload" the image and use the `Blob` browser API then I think we'll need to make some further modifications.

The image is being displayed as an `<img>` element, but the boundary boxes / labels returned from the Azure API are just being `console.log`ed right now, so that is ready to be integrated with Konva!